### PR TITLE
Fix extremely thin font on Retina Mac Screens

### DIFF
--- a/app/styles/evaluate.scss
+++ b/app/styles/evaluate.scss
@@ -56,7 +56,7 @@ h3 + .collapsing {
     label {
         display:inline-block;
         padding:3px;
-        font-weight:100;
+        font-weight:normal;
         margin-bottom:0;
         &::after { margin-bottom:0;}
     }


### PR DESCRIPTION
<img width="744" alt="Screenshot of Technology selection with very thin font used" src="https://cloud.githubusercontent.com/assets/58862/21614626/8181ff2c-d1da-11e6-800b-1456852f1c2c.png">

It is very hard to read.