### PR TITLE
Fix import of audit data in case where it is missing criteria

### DIFF
--- a/app/scripts/models/evaluation/audit.js
+++ b/app/scripts/models/evaluation/audit.js
@@ -8,14 +8,7 @@ evalScopeModel, wcag2spec, CriterionAssert) {
     var criteria = {};
 
     wcag2spec.onLangChange(function () {
-        wcag2spec.getCriteria()
-        .forEach(function (spec) {
-            if (typeof criteria[spec.id] === 'undefined') {
-                auditModel.addCritAssert({
-                    'test': spec.id
-                });
-            }
-        });
+        auditModel.restoreMissingCriteria();
     });
 
     auditModel = {
@@ -62,7 +55,19 @@ evalScopeModel, wcag2spec, CriterionAssert) {
                 auditModel.criteria = criteria;
 
                 evalData.auditResult.forEach(auditModel.addCritAssert);
+                auditModel.restoreMissingCriteria();
             }
+        },
+
+        restoreMissingCriteria: function() {
+            wcag2spec.getCriteria()
+            .forEach(function (spec) {
+                if (typeof criteria[spec.id] === 'undefined') {
+                    auditModel.addCritAssert({
+                        'test': spec.id
+                    });
+                }
+            });
         },
 
         getCritAssert: function (idref) {


### PR DESCRIPTION
Currently the tool fails to generate the report correctly (among other bugs) if the imported audit JSON does not include every criterion in the bundled spec JSON. This is unlikely to occur at the moment but will become an issue once WCAG 2.1 is incorporated, adding new criteria.