### PR TITLE
Fix site name in generated report

### DIFF
--- a/app/views/report/scope.html
+++ b/app/views/report/scope.html
@@ -1,6 +1,6 @@
 <table>
   <tr><th>{{'HTML_REPORT.LABEL_SITE_NAME' | translate}}</th>
-      <td>{{scope.website.title}}</td></tr>
+      <td>{{scope.website.siteName}}</td></tr>
 
   <tr>
     <th>{{'HTML_REPORT.LABEL_SITE_SCOPE' | translate}}</th>


### PR DESCRIPTION
Before this fix the site name field is always blank in the generated report.