### PR TITLE
Step 2: add missing translation function to close buttons

### DIFF
--- a/app/views/evaluation/explore.html
+++ b/app/views/evaluation/explore.html
@@ -15,7 +15,7 @@
     title="{{ 'EXPLORE.HD_RELIEDUP_TECH' | translate }}"></info-button>
   </h2>
 
-  <info-field ref="inf_reliedup_tech" button="Close info">
+  <info-field ref="inf_reliedup_tech" button="{{'COMMON.BTN_CLOSE_INFO' | translate}}">
     <p ng-bind-html="'EXPLORE.INF_RELIEDUP_TECH' | translate: {
       link_em_2d: 'http://www.w3.org/TR/WCAG-EM/#step2d',
       link_relied_upon: 'https://www.w3.org/TR/WCAG21/#dfn-relied-upon'
@@ -108,7 +108,7 @@
     title="{{ 'EXPLORE.HD_NOTE_TAKING' | translate }}"></info-button>
   </h2>
 
-  <info-field ref="inf_notes" button="Close info">
+  <info-field ref="inf_notes" button="{{'COMMON.BTN_CLOSE_INFO' | translate}}">
     <p ng-bind-html="'EXPLORE.INF_NOTE_TAKING' | translate"></p>
   </info-field>
 


### PR DESCRIPTION
Two button labels for "Close info" where still hard-coded into step 2 (explore). This PR replaces the strings with the translate function.