### PR TITLE
Add guard for criterion versions in filter

### DIFF
--- a/app/scripts/controllers/evaluation/audit/criteria.js
+++ b/app/scripts/controllers/evaluation/audit/criteria.js
@@ -86,7 +86,9 @@ angular.module('wcagReporter')
     }
 
     function criterionMatchFilter (criterion) {
-      var versionActive = (activeFilters.indexOf(criterion.versions[0]) !== -1);
+      var versionActive = criterion.versions
+        ? (activeFilters.indexOf(criterion.versions[0]) !== -1)
+        : true;
       var levelActive = (activeFilters.indexOf(criterion.level) !== -1);
 
       if (


### PR DESCRIPTION
thats better...

Prevent version filtering to not show wcag 2.0 translated data due to missing versioning