### PR TITLE
[2021 Redesign] Move “import data” button to audit screen

### DIFF
--- a/src/components/layouts/BaseLayout.svelte
+++ b/src/components/layouts/BaseLayout.svelte
@@ -56,7 +56,6 @@
             {TRANSLATED.BUTTON_NEW_EVALUATION}
           </Button>
           <OpenEvaluation />
-          <AuditorImport />
         </Panel>
       </GridItem>
     {/if}

--- a/src/components/pages/Evaluation/AuditPage.svelte
+++ b/src/components/pages/Evaluation/AuditPage.svelte
@@ -1,6 +1,6 @@
 <Page title="{TRANSLATED.PAGE_TITLE}">
   <p>{@html TRANSLATED.INTRODUCTION}</p>
-
+  <AuditorImport />
   <Auditor />
 </Page>
 
@@ -8,6 +8,7 @@
   import { getContext } from 'svelte';
 
   import Auditor from '@app/components/ui/Auditor/Auditor.svelte';
+  import AuditorImport from '@app/components/ui/Auditor/AuditorImport.svelte';
   import Page from '@app/components/ui/Page.svelte';
 
   const { translate } = getContext('app');

--- a/src/components/ui/Auditor/AuditorImport.svelte
+++ b/src/components/ui/Auditor/AuditorImport.svelte
@@ -1,8 +1,16 @@
-<File
-  id="import__assertions"
-  label="{TRANSLATED.BUTTON}"
-  on:change="{handleChange}"
-/>
+<div class="AuditorImport">
+  <File
+    id="import__assertions"
+    label="{TRANSLATED.BUTTON}"
+    on:change="{handleChange}"
+  />
+</div>
+
+<style>
+.AuditorImport {
+  display: inline-block;
+}
+</style>
 
 <script>
   import { getContext } from 'svelte';


### PR DESCRIPTION
(Re: issue #373)

This moves the “Import data” button to the audit screen, and also makes it display inline. 

I regret the extra `div`, but feel it is the most resilient way to make this particular instance of the `File` component inline, without touching other components.