### PR TITLE
[2021 Redesign] Use WAI’s your report styles, only use all buttons on homepage (fixes #373)

### DIFF
--- a/src/components/layouts/BaseLayout.svelte
+++ b/src/components/layouts/BaseLayout.svelte
@@ -109,6 +109,8 @@
 
   import { routes } from '@app/stores/appStore.js';
   import locales from '@app/locales/index.json';
+  import tests from '@app/stores/earl/testStore/index.js';
+
 
   import Grid from '@app/components/ui/Grid.svelte';
   import GridItem from '@app/components/ui/GridItem.svelte';
@@ -118,32 +120,43 @@
   import Panel from '@app/components/ui/Panel.svelte';
 
   const location = useLocation();
-  const { translate } = getContext('app');
-  let panelIsOpen = true;
-
+  const navigate = useNavigate();
+  const { translate, translateToObject, scopeStore } = getContext('app');
+  
   $: TRANSLATED = {
+    PRINCIPLES: $translateToObject('WCAG.WCAG21.PRINCIPLE'),
+    BUTTON_NEW_EVALUATION: $translate('UI.NAV.MENU_NEW', {
+      default: 'New report'
+    }),
     HEADING_PANEL: $translate('UI.COMMON.YOUR_REPORT', {
       default: 'Your report'
     }),
     STEP: $translate('UI.NAV.STEP', { default: 'step' }),
     VIEW_REPORT: $translate('UI.NAV.STEP_VIEWREPORT', {
       default: 'View report'
-    })
+    }),
+    CONFORMANCE_LEVEL: $translate('WCAG.COMMON.CONFORMANCE_LEVEL')
   };
 
   $: hasPanel = 
     ($location.pathname !== $routes.OVERVIEW.path) &&
     ($location.pathname !== $routes.VIEW_REPORT.path);
   $: isViewReport = $location.pathname === $routes.VIEW_REPORT.path;
+  $: console.log($assertions);
 
   $: pagerContext = Object.keys($routes).map((key) => {
     return $routes[key];
   });
 
-  const principles = ["Perceivable", "Operable", "Understandable", "Robust"];
+  $: principles = [...new Set($tests.map((a) => a.num.split('.')[0]))];
 
-  $: totalEvaluated = 5;
-  $: totalToEvaluate = 50;
-  $: conformanceTarget = "Level A, AA";
+  $: totalToEvaluate = $assertions.length;
+  $: totalEvaluated = $assertions.filter(assertion => 
+    assertion.result.description !== undefined && 
+    assertion.result.outcome.id !== "earl:untested").length;
+
+  $:  console.log('totalevaluated', totalEvaluated);
+  $: conformanceTarget = $scopeStore['CONFORMANCE_TARGET'];
   $: percentageEvaluated = (totalEvaluated / totalToEvaluate) * 100;
+  
 </script>

--- a/src/components/layouts/BaseLayout.svelte
+++ b/src/components/layouts/BaseLayout.svelte
@@ -32,54 +32,16 @@
 
 <div class="BaseLayout">
   <Grid>
-    <GridItem area="{!isViewReport || panelIsOpen ? 'content' : 'full'}" row="1">
+    <GridItem area="{panelIsOpen ? 'content' : 'full'}" row="1">
       <slot />
-
-      {#if onOverviewPage}
-      <Button type="secondary" on:click="{handleNewEvaluationClick}">
-        {TRANSLATED.BUTTON_NEW_EVALUATION}
-      </Button>
-      <OpenEvaluation />
-      {/if}
-
       <Pager label="{TRANSLATED.STEP}" context="{pagerContext}" />
     </GridItem>
 
     <GridItem area="right" row="1">
       {#if hasPanel}
-      <Panel title="{TRANSLATED.HEADING_PANEL}" bind:open="{panelIsOpen}">
-
-        <p class="your-report__description">Reported on {$totalEvaluated} of {$totalToEvaluate} {conformanceTarget} Success Criteria.</p>
-
-        <div class="progress-bar ">
-          <span class="progress-bar__progress" style="width: {percentageEvaluated}%">
-            <span class="visuallyhidden">
-              {percentageEvaluated}%
-            </span>
-          </div>
-        
-          <ul class="your-report__progress-by-principle">
-            {#each principles as principle}
-            <li class="progress">
-              <div class="progress__principle">
-                <a href="#@@@" class="principle__name">
-                  <span>{TRANSLATED.PRINCIPLES[principle].TITLE}</span>
-                </a> 
-                <span class="progress__part">3 of 6</span>
-              </div>
-              <div class="progress-bar">
-                <span class="progress-bar__progress" style="width: 50%">
-                <span class="visuallyhidden">50 %</span></span>
-              </div>
-            </li>
-            {/each}
-          </ul>
-        
-          <Link class="button" to="/evaluation/view-report">
-            {TRANSLATED.VIEW_REPORT}
-          </Link>
-        </Panel>
-    {/if}
+      <ProgressPanel {panelIsOpen}></ProgressPanel>
+      {/if}
+      </GridItem>
   </Grid>
 </div>
 <!-- /@Layout -->
@@ -98,66 +60,36 @@
       padding: 2em 0;
     }
   }
-
-  .your-report__progress-by-principle {
-    columns: 1;
-  }
 </style>
 
 <script>
   import { getContext } from 'svelte';
-  import { useLocation, Link } from 'svelte-navigator';
+  import { useLocation } from 'svelte-navigator';
 
   import { routes } from '@app/stores/appStore.js';
   import locales from '@app/locales/index.json';
-  import wcag from '@app/stores/wcagStore.js';
-
 
   import Grid from '@app/components/ui/Grid.svelte';
   import GridItem from '@app/components/ui/GridItem.svelte';
   import LanguageSelect from '@app/components/ui/LanguageSelect.svelte';
   import NavigationBar from '@app/components/ui/NavigationBar.svelte';
   import Pager from '@app/components/ui/Pager.svelte';
-  import Panel from '@app/components/ui/Panel.svelte';
+  import ProgressPanel from '@app/components/ui/ProgressPanel.svelte';
 
   const location = useLocation();
-  const navigate = useNavigate();
-  const { translate, translateToObject, scopeStore } = getContext('app');
-  
+  const { translate, translateToObject } = getContext('app');
+
+  let panelIsOpen = true;
+
   $: TRANSLATED = {
-    PRINCIPLES: $translateToObject('WCAG.PRINCIPLE'),
-    BUTTON_NEW_EVALUATION: $translate('UI.NAV.MENU_NEW', {
-      default: 'New report'
-    }),
-    HEADING_PANEL: $translate('UI.COMMON.YOUR_REPORT', {
-      default: 'Your report'
-    }),
     STEP: $translate('UI.NAV.STEP', { default: 'step' }),
-    VIEW_REPORT: $translate('UI.NAV.STEP_VIEWREPORT', {
-      default: 'View report'
-    }),
-    CONFORMANCE_LEVEL: $translate('WCAG.COMMON.CONFORMANCE_LEVEL')
   };
 
-  $: hasPanel = 
-    ($location.pathname !== $routes.OVERVIEW.path) &&
-    ($location.pathname !== $routes.VIEW_REPORT.path);
+  $: hasPanel = !isViewReport && !isOverview;
   $: isViewReport = $location.pathname === $routes.VIEW_REPORT.path;
-  $: console.log($assertions);
+  $: isOverview = $location.pathname === $routes.OVERVIEW.path;
 
   $: pagerContext = Object.keys($routes).map((key) => {
     return $routes[key];
-  });
-
-  $: principles = [...new Set($wcag.map((a) => a.num.split('.')[0]))];
-
-  $: totalToEvaluate = $assertions.length;
-  $: totalEvaluated = $assertions.filter(assertion => 
-    assertion.result.description !== undefined && 
-    assertion.result.outcome.id !== "earl:untested").length;
-
-  $:  console.log('totalevaluated', totalEvaluated);
-  $: conformanceTarget = $scopeStore['CONFORMANCE_TARGET'];
-  $: percentageEvaluated = (totalEvaluated / totalToEvaluate) * 100;
-  
+  });  
 </script>

--- a/src/components/layouts/BaseLayout.svelte
+++ b/src/components/layouts/BaseLayout.svelte
@@ -41,6 +41,38 @@
     <GridItem area="right" row="1">
       {#if hasPanel}
       <Panel title="{TRANSLATED.HEADING_PANEL}" bind:open="{panelIsOpen}">
+
+        <p class="your-report__description">Reported on {totalEvaluated} of {totalToEvaluate} {conformanceTarget} Success Criteria.</p>
+
+        <div class="progress-bar ">
+          <span class="progress-bar__progress" style="width: {percentageEvaluated}%">
+            <span class="visuallyhidden">
+              {percentageEvaluated}%
+            </span>
+          </span>
+        </div>
+      
+        <ul class="your-report__progress-by-principle">
+          {#each principles as principle}
+          <li class="progress">
+            <div class="progress__principle">
+              <a href="#@@@" class="principle__name">
+                <span>{principle}</span>
+              </a> 
+              <span class="progress__part">3 of 6</span>
+            </div>
+            <div class="progress-bar">
+              <span class="progress-bar__progress" style="width: 50%">
+              <span class="visuallyhidden">50 %</span></span>
+            </div>
+          </li>
+          {/each}
+        </ul>
+      
+        <Link class="button" to="/evaluation/view-report">
+          {TRANSLATED.VIEW_REPORT}
+        </Link>
+
         <Link class="button" to="/evaluation/view-report">
           {TRANSLATED.VIEW_REPORT}
         </Link>
@@ -64,6 +96,10 @@
     .BaseLayout {
       padding: 2em 0;
     }
+  }
+
+  .your-report__progress-by-principle {
+    columns: 1;
   }
 </style>
 
@@ -104,4 +140,10 @@
     return $routes[key];
   });
 
+  const principles = ["Perceivable", "Operable", "Understandable", "Robust"];
+
+  $: totalEvaluated = 5;
+  $: totalToEvaluate = 50;
+  $: conformanceTarget = "Level A, AA";
+  $: percentageEvaluated = (totalEvaluated / totalToEvaluate) * 100;
 </script>

--- a/src/components/layouts/BaseLayout.svelte
+++ b/src/components/layouts/BaseLayout.svelte
@@ -35,6 +35,13 @@
     <GridItem area="{!isViewReport || panelIsOpen ? 'content' : 'full'}" row="1">
       <slot />
 
+      {#if onOverviewPage}
+      <Button type="secondary" on:click="{handleNewEvaluationClick}">
+        {TRANSLATED.BUTTON_NEW_EVALUATION}
+      </Button>
+      <OpenEvaluation />
+      {/if}
+
       <Pager label="{TRANSLATED.STEP}" context="{pagerContext}" />
     </GridItem>
 
@@ -42,44 +49,38 @@
       {#if hasPanel}
       <Panel title="{TRANSLATED.HEADING_PANEL}" bind:open="{panelIsOpen}">
 
-        <p class="your-report__description">Reported on {totalEvaluated} of {totalToEvaluate} {conformanceTarget} Success Criteria.</p>
+        <p class="your-report__description">Reported on {$totalEvaluated} of {$totalToEvaluate} {conformanceTarget} Success Criteria.</p>
 
         <div class="progress-bar ">
           <span class="progress-bar__progress" style="width: {percentageEvaluated}%">
             <span class="visuallyhidden">
               {percentageEvaluated}%
             </span>
-          </span>
-        </div>
-      
-        <ul class="your-report__progress-by-principle">
-          {#each principles as principle}
-          <li class="progress">
-            <div class="progress__principle">
-              <a href="#@@@" class="principle__name">
-                <span>{principle}</span>
-              </a> 
-              <span class="progress__part">3 of 6</span>
-            </div>
-            <div class="progress-bar">
-              <span class="progress-bar__progress" style="width: 50%">
-              <span class="visuallyhidden">50 %</span></span>
-            </div>
-          </li>
-          {/each}
-        </ul>
-      
-        <Link class="button" to="/evaluation/view-report">
-          {TRANSLATED.VIEW_REPORT}
-        </Link>
-
-        <Link class="button" to="/evaluation/view-report">
-          {TRANSLATED.VIEW_REPORT}
-        </Link>
-      </Panel>
-      {/if}
-  </GridItem>
-</Grid>
+          </div>
+        
+          <ul class="your-report__progress-by-principle">
+            {#each principles as principle}
+            <li class="progress">
+              <div class="progress__principle">
+                <a href="#@@@" class="principle__name">
+                  <span>{TRANSLATED.PRINCIPLES[principle].TITLE}</span>
+                </a> 
+                <span class="progress__part">3 of 6</span>
+              </div>
+              <div class="progress-bar">
+                <span class="progress-bar__progress" style="width: 50%">
+                <span class="visuallyhidden">50 %</span></span>
+              </div>
+            </li>
+            {/each}
+          </ul>
+        
+          <Link class="button" to="/evaluation/view-report">
+            {TRANSLATED.VIEW_REPORT}
+          </Link>
+        </Panel>
+    {/if}
+  </Grid>
 </div>
 <!-- /@Layout -->
 

--- a/src/components/layouts/BaseLayout.svelte
+++ b/src/components/layouts/BaseLayout.svelte
@@ -109,7 +109,7 @@
 
   import { routes } from '@app/stores/appStore.js';
   import locales from '@app/locales/index.json';
-  import tests from '@app/stores/earl/testStore/index.js';
+  import wcag from '@app/stores/wcagStore.js';
 
 
   import Grid from '@app/components/ui/Grid.svelte';
@@ -124,7 +124,7 @@
   const { translate, translateToObject, scopeStore } = getContext('app');
   
   $: TRANSLATED = {
-    PRINCIPLES: $translateToObject('WCAG.WCAG21.PRINCIPLE'),
+    PRINCIPLES: $translateToObject('WCAG.PRINCIPLE'),
     BUTTON_NEW_EVALUATION: $translate('UI.NAV.MENU_NEW', {
       default: 'New report'
     }),
@@ -148,7 +148,7 @@
     return $routes[key];
   });
 
-  $: principles = [...new Set($tests.map((a) => a.num.split('.')[0]))];
+  $: principles = [...new Set($wcag.map((a) => a.num.split('.')[0]))];
 
   $: totalToEvaluate = $assertions.length;
   $: totalEvaluated = $assertions.filter(assertion => 

--- a/src/components/ui/Panel.svelte
+++ b/src/components/ui/Panel.svelte
@@ -25,13 +25,20 @@
       on:click={toggle}
       aria-expanded="{open}"
     >
-      {@html TRANSLATED.SHOW_HIDE}
       <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <polyline points="15 18 9 12 15 6"></polyline>
-    </svg>
+      </svg>
+      {@html TRANSLATED.SHOW_HIDE}
     </button>
   {/if}
 </aside>
+
+<style>
+.your-report__showhide[aria-expanded="false"] svg {
+  margin-right: .25em;
+  margin-left: 0;
+}
+</style>
 
 <script>
   import { getContext } from 'svelte';

--- a/src/components/ui/Panel.svelte
+++ b/src/components/ui/Panel.svelte
@@ -1,102 +1,37 @@
-<aside class="Panel your-report" class:hidden="{!open}">
-  <header class="Panel__Header">
-    {#if title}
-      <h2 class="Panel__Header__heading">{title}</h2>
-    {/if}
+<aside class="Panel your-report" class:your-report--expanded="{open}">
+  {#if open}
+  <h2 class="Panel__Header__heading your-report__heading">
+    {title}
+
     <button
       type="button"
-      class="Panel__Toggle button-small showhidebutton"
-      on:click="{handleToggleClick}"
+      class="button-secondary button-small your-report__showhide"
+      on:click={toggle}
       aria-expanded="{open}"
-    >{@html TRANSLATED.SHOW_HIDE}</button>
-  </header>
+    >
+      {@html TRANSLATED.SHOW_HIDE}
+      <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <polyline points="9 18 15 12 9 6"></polyline>
+    </svg>
+    </button>
+  </h2>
 
-  <div class="Panel__Body" hidden="{!open}">
-    <slot />
-  </div>
+  <slot />
+
+  {:else}
+    <button
+      type="button"
+      class="button-secondary button-small your-report__showhide"
+      on:click={toggle}
+      aria-expanded="{open}"
+    >
+      {@html TRANSLATED.SHOW_HIDE}
+      <svg aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <polyline points="15 18 9 12 15 6"></polyline>
+    </svg>
+    </button>
+  {/if}
 </aside>
-
-<style>
-  .Panel {
-    box-sizing: border-box;
-    border: 1px solid var(--line-grey);
-    padding: 1em;
-    width: 100%;
-    background-color: var(--footer-grey);
-    box-shadow: 0px 2px 8px -7px #000;
-  }
-
-  .Panel.hidden {
-    width: auto;
-    padding: 1em;
-    border-color: transparent;
-    background-color: transparent;
-    box-shadow: none;
-  }
-
-  @media (min-width: 60em) {
-    .Panel {
-      position: sticky;
-      top: 1em;
-    }
-  }
-  .Panel__Header {
-    display: flex;
-    align-items: flex-start;
-    justify-content: flex-start;
-    border-bottom: 1px solid var(--line-grey);
-    margin-bottom: 1em;
-  }
-
-  .Panel.hidden > .Panel__Header {
-    border-bottom-color: transparent;
-  }
-
-  .Panel__Header__heading {
-    margin: 0;
-    margin-right: 1em;
-    border-bottom: none;
-    font-size: 1em;
-    line-height: 1.5;
-    font-weight: bold;
-  }
-
-  .Panel.hidden .Panel__Header__heading {
-    display: none;
-  }
-
-  .Panel:not(.hidden) > .Panel__Body {
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-start;
-    align-items: stretch;
-  }
-
-  :global(.Panel__Body > *:not(:last-child)) {
-    margin: 0 0 1em;
-  }
-
-  :global(.Panel__Body > :last-child) {
-    margin-bottom: 0;
-  }
-
-  .Panel__Toggle {
-    flex-shrink: 0;
-    margin-left: auto;
-    padding: 0.25em;
-    cursor: pointer;
-    word-wrap: break-word;
-  }
-
-  .Panel.hidden .Panel__Toggle {
-    flex-shrink: 1;
-  }
-
-  .showhidebutton::after {
-    /* Corrections */
-    margin-left: 0.5em;
-  }
-</style>
 
 <script>
   import { getContext } from 'svelte';
@@ -118,9 +53,7 @@
         })
   };
 
-  function handleToggleClick() {
-    let toggleTo = !open;
-
-    open = toggleTo;
+  function toggle() {
+    open = !open;
   }
 </script>

--- a/src/components/ui/ProgressBar.svelte
+++ b/src/components/ui/ProgressBar.svelte
@@ -1,0 +1,10 @@
+<div class="progress-bar">
+  <span class="progress-bar__progress" style={`width: ${percentage}%`}>
+    <span class="visuallyhidden">{percentage} %</span>
+  </span>
+</div>
+
+<script>
+  export let percentage = 0;
+</script>
+

--- a/src/components/ui/ProgressPanel.svelte
+++ b/src/components/ui/ProgressPanel.svelte
@@ -1,0 +1,76 @@
+<Panel title="{TRANSLATED.HEADING_PANEL}" bind:open="{panelIsOpen}">
+
+  <p class="your-report__description">Reported on {totalEvaluated} of {totalToEvaluate} WCAG {wgacVersion} {conformanceTarget} Success Criteria.</p>
+
+  <ProgressBar percentage={percentageEvaluated}></ProgressBar>
+  
+  <ul class="your-report__progress-by-principle">
+    {#each principles as principle}
+    <li class="progress">
+      <div class="progress__principle">
+        <a href="#@@@" class="principle__name">
+          <span>{TRANSLATED.PRINCIPLES[principle].TITLE}</span>
+        </a> 
+        <span class="progress__part">3 of 6</span>
+      </div>
+      <ProgressBar percentage="50"></ProgressBar>
+    </li>
+    {/each}
+  </ul>
+  
+  <Link class="button" to="/evaluation/view-report">
+    {TRANSLATED.VIEW_REPORT}
+  </Link>
+</Panel>
+
+<style>  
+.your-report__progress-by-principle {
+  columns: 1;
+}
+</style>
+
+<script>
+  import { getContext } from 'svelte';
+  import { useLocation, Link } from 'svelte-navigator';
+
+  import Panel from '@app/components/ui/Panel.svelte';
+  import ProgressBar from '@app/components/ui/ProgressBar.svelte';
+
+  import wcag from '@app/stores/wcagStore.js';
+  import assertions from '@app/stores/earl/assertionStore/index.js';
+
+  const { translate, translateToObject, scopeStore } = getContext('app');
+
+  $: TRANSLATED = {
+    PRINCIPLES: $translateToObject('WCAG.PRINCIPLE'),
+    BUTTON_NEW_EVALUATION: $translate('UI.NAV.MENU_NEW', {
+      default: 'New report'
+    }),
+    HEADING_PANEL: $translate('UI.COMMON.YOUR_REPORT', {
+      default: 'Your report'
+    }),
+    STEP: $translate('UI.NAV.STEP', { default: 'step' }),
+    VIEW_REPORT: $translate('UI.NAV.STEP_VIEWREPORT', {
+      default: 'View report'
+    }),
+    CONFORMANCE_LEVEL: $translate('WCAG.COMMON.CONFORMANCE_LEVEL')
+  };
+
+  $:  console.log('totalevaluated', totalEvaluated);
+  $: conformanceTarget = $scopeStore['CONFORMANCE_TARGET'];
+  $: wgacVersion = $scopeStore['WCAG_VERSION'];
+  $: percentageEvaluated = (totalEvaluated / totalToEvaluate) * 100;
+
+  $: principles = [...new Set($wcag.map((a) => a.num.split('.')[0]))];
+
+  $: console.log($assertions);
+
+  let totalEvaluated = 3;
+
+  export let panelIsOpen = true;
+
+  $: totalToEvaluate = $assertions.length;
+  $: totalEvaluated = $assertions.filter(assertion => 
+    assertion.result.description !== undefined && 
+    assertion.result.outcome.id !== "earl:untested").length;
+</script>

--- a/src/static/css/global.css
+++ b/src/static/css/global.css
@@ -56,18 +56,6 @@
   background-color: white;
 }
 
-/* Normalize svgees */
-svg {
-  width: 1em;
-  height: 1em;
-  line-height: 1;
-  font-size: inherit;
-  stroke-width: 0;
-  stroke: currentColor;
-  fill: currentColor;
-  background-color: transparent;
-}
-
 /*
  * Remove default focus styles from elements that
  * otherwise should not receive focus.


### PR DESCRIPTION

## Added functionality

* Now has progress bar to show what that would look like (data is hard coded, see todos below)
* Different amount of buttons depending on where you are: _all_ on Overview page, 'View report' on all other pages
* Gets conformance target from correct store (eg “WCAG 2.1, Level A, AA”)
* Gets names of principles from store
* Uses “your report” box from [WAI Design Components](https://wai-website-theme.netlify.app/components/your-report/) where possible

