### PR TITLE
Cleanup evaluation store

### DIFF
--- a/src/stores/collectionStore.js
+++ b/src/stores/collectionStore.js
@@ -25,5 +25,13 @@ export default function collectionStore(Item, initialCollection = []) {
     });
   };
 
+  // Re-initialize
+  collection.reset = function reset() {
+    console.log('Collection reset', initialCollection);
+    collection.update(() => {
+      return [...initialCollection];
+    });
+  };
+
   return collection;
 }

--- a/src/stores/evaluationStore.js
+++ b/src/stores/evaluationStore.js
@@ -16,7 +16,11 @@ import scopeStore, { initialScopeStore } from '@app/stores/scopeStore.js';
 import exploreStore, { initialExploreStore } from '@app/stores/exploreStore.js';
 import sampleStore, { initialSampleStore } from '@app/stores/sampleStore.js';
 import summaryStore, { initialSummaryStore } from '@app/stores/summaryStore.js';
-import { getCriterionById } from '@app/stores/wcagStore.js';
+import {
+  DEFAULT_WCAG_VERSION,
+  DEFAULT_CONFORMANCE_LEVEL,
+  getCriterionById
+} from '@app/stores/wcagStore.js';
 
 import assertions, {
   AssertionTypes
@@ -93,8 +97,8 @@ class EvaluationModel {
         // WEBSITE_SCOPE
         description: ''
       },
-      wcagVersion: '2.1',
-      conformanceTarget: 'AA',
+      wcagVersion: DEFAULT_WCAG_VERSION,
+      conformanceTarget: DEFAULT_CONFORMANCE_LEVEL,
       accessibilitySupportBaseline: '',
       additionalEvaluationRequirements: ''
     };
@@ -275,7 +279,7 @@ class EvaluationModel {
         language = framedEvaluation.language || 'en';
         locale.set(language);
 
-        wcagVersion = defineScope.wcagVersion || '2.1';
+        wcagVersion = defineScope.wcagVersion || DEFAULT_WCAG_VERSION;
 
         /**
          * Start setting values from the imported json-ld.

--- a/src/stores/evaluationStore.js
+++ b/src/stores/evaluationStore.js
@@ -147,11 +147,9 @@ class EvaluationModel {
       return { ...initialExploreStore };
     });
 
-    assertions.update(() => []);
+    assertions.reset();
 
-    subjects.update(() => {
-      return [...initialSubjectStore];
-    });
+    subjects.reset();
 
     summaryStore.update(() => {
       return { ...initialSummaryStore };

--- a/src/stores/wcagStore.js
+++ b/src/stores/wcagStore.js
@@ -4,8 +4,10 @@ import scopeStore from '@app/stores/scopeStore.js';
 import wcagCriteriaData from '@app/data/wcag.json';
 
 export const CONFORMANCE_LEVELS = ['A', 'AA', 'AAA'];
+export const DEFAULT_CONFORMANCE_LEVEL = 'AA';
 
 export const WCAG_VERSIONS = Object.keys(wcagCriteriaData);
+export const DEFAULT_WCAG_VERSION = WCAG_VERSIONS.slice(-1)[0];
 
 export const scopedWcagVersions = derived([scopeStore], ([$scopeStore]) => {
   const { WCAG_VERSION } = $scopeStore;


### PR DESCRIPTION
This PR will make sure all data is picked up correctly with the Evaluation model.

# Cleanup

- [x] Move all functionality that should belong to other stores over
- [ ] Improve readability

# Step 1: Scope

- [x] Improve Wcag Version detection from previous tool versions
- [ ] Conformance level target

# Step 5: Report findings

- [ ]  Evaluator name
- [x] Datefield

