### PR TITLE
Add view in report links (fixes #380)

### DIFF
--- a/src/components/form/EarlResult.svelte
+++ b/src/components/form/EarlResult.svelte
@@ -11,7 +11,7 @@
  * Important here is to pass the correct result,
  * so test AND subject should always match.
  * -->
-<fieldset class="Criterion__Result__container">
+<fieldset class="Criterion__Result">
   <legend class="Criterion__Subject">
     {#if label}
       {label}
@@ -20,30 +20,30 @@
     {/if}
   </legend>
 
-  <Flex direction="row" align="start" justify="between" wrap>
-    <div class="Criterion__Result--outcome">
-      <Select
-        id="{`assertion__${_assertion.ID}--result__outcome`}"
-        label="{$translate('PAGES.AUDIT.LABEL_OUTCOME')}"
-        options="{outcomeOptions}"
-        bind:value="{_assertion.result.outcome.id}"
-        on:change="{handleOutcomeChange}"
-      />
-    </div>
+  <div class="Criterion__Fields">
+    <Select
+      id="{`assertion__${_assertion.ID}--result__outcome`}"
+      label="{$translate('PAGES.AUDIT.LABEL_OUTCOME')}"
+      options="{outcomeOptions}"
+      bind:value="{_assertion.result.outcome.id}"
+      on:change="{handleOutcomeChange}"
+    />
 
-    <div class="Criterion__Result--description">
-      <Textarea
-        id="{`assertion__${_assertion.ID}--result__description`}"
-        label="{$translate('PAGES.AUDIT.ASSERTION_RESULT_DESCRIPTION_LABEL')}"
-        bind:value="{_assertion.result.description}"
-        on:change="{handleResultChange}"
-      />
-    </div>
-  </Flex>
+    <Textarea
+      id="{`assertion__${_assertion.ID}--result__description`}"
+      label="{$translate('PAGES.AUDIT.ASSERTION_RESULT_DESCRIPTION_LABEL')}"
+      bind:value="{_assertion.result.description}"
+      on:change="{handleResultChange}"
+    >
+      <span slot="before-textarea" class="view-in-report">
+      <Link to={`/evaluation/view-report#criterion-${_assertion.test.num.replaceAll('.', '')}`}>{TRANSLATED.VIEW_IN_REPORT}</Link>
+      </span>
+    </Textarea>
+  </div>
 </fieldset>
 
 <style>
-  .Criterion__Result__container {
+  .Criterion__Result {
     display: block;
     border: none;
   }
@@ -52,15 +52,18 @@
     padding: 0;
     font-size: 1em;
   }
-
-  .Criterion__Result--outcome {
-    margin-right: 2rem;
+  .Criterion__Fields {
+    display: flex;
+    gap: 2rem;
   }
-
-  .Criterion__Result--description {
-    flex-basis: 15rem;
-    flex-grow: 1;
-    flex-shrink: 1;
+  :global(.Criterion__Fields :last-child) {
+    flex: 2;
+  }
+  :global(.Criterion__Fields :last-child label) {
+    float: left;
+  }
+  .view-in-report {
+    float: right;
   }
 </style>
 
@@ -73,9 +76,10 @@
    */
 
   import { getContext } from 'svelte';
+  import { Link } from 'svelte-navigator';
+
   import assertions from '@app/stores/earl/assertionStore/index.js';
 
-  import Flex from '@app/components/ui/Flex.svelte';
   import Select from '@app/components/form/Select.svelte';
   import Textarea from '@app/components/form/Textarea.svelte';
 
@@ -88,6 +92,10 @@
 
   const { translate } = getContext('app');
   const { outcomeValues } = getContext('Evaluation');
+
+  $: TRANSLATED = {
+    VIEW_IN_REPORT: $translate('PAGES.AUDIT.VIEW_IN_REPORT')
+  };
 
   $: outcomeOptions = $outcomeValues.map((outcomeValue, index) => {
     const title = outcomeValue.title;

--- a/src/components/form/Field.svelte
+++ b/src/components/form/Field.svelte
@@ -15,7 +15,9 @@
   .Field {
     padding: 0;
   }
-
+  .Field label {
+    display: block;
+  }
   :global(.Field > *:not(:last-child)) {
     margin-bottom: 0.5em;
   }

--- a/src/components/form/Field.svelte
+++ b/src/components/form/Field.svelte
@@ -1,4 +1,4 @@
-<div class="Field field">
+<div class="Field">
   {#if helptext}
     <HelpText
       label="{label && `<label for="${id}">${label}</label>`}"
@@ -14,6 +14,7 @@
 <style>
   .Field {
     padding: 0;
+    margin-bottom: 2rem;
   }
   .Field label {
     display: block;

--- a/src/components/form/Textarea.svelte
+++ b/src/components/form/Textarea.svelte
@@ -1,6 +1,14 @@
-<Field id="{id}" label="{label}" helptext="{helptext}">
+<Field {id} {label} {helptext}>
+  <slot name="before-textarea"></slot>
   <textarea id="{id}" rows="5" bind:value on:change></textarea>
 </Field>
+
+<style>
+  textarea {
+    display: block;
+    width: 100%;
+  }
+</style>
 
 <script>
   import Field from './Field.svelte';

--- a/src/components/ui/Auditor/Auditor.svelte
+++ b/src/components/ui/Auditor/Auditor.svelte
@@ -16,7 +16,6 @@
 
   .Auditor__samples {
     grid-area: left;
-    grid-row: 2 / span 2;
   }
 
   :global(.Auditor .Auditor__Filters > *) {
@@ -25,8 +24,7 @@
   }
 
   .Auditor__Assertions {
-    grid-area: content;
-    grid-row: 2;
+    grid-column: 1 / 8;
     margin: 0;
     padding: 0;
     list-style-type: none;

--- a/src/components/ui/Auditor/AuditorFilter.svelte
+++ b/src/components/ui/Auditor/AuditorFilter.svelte
@@ -30,8 +30,7 @@
 
 <style>
   .Auditor__Filter {
-    grid-column: 1 / content-end;
-    grid-row: 1;
+    grid-column: 1 / 8;
     margin: 2em 0 0;
   }
 

--- a/src/components/ui/Auditor/AuditorSummary.svelte
+++ b/src/components/ui/Auditor/AuditorSummary.svelte
@@ -12,7 +12,7 @@
     {#each guidelineCriteria(guideline) as criterion (criterion.num)}
       <div class="Auditor__Assertion">
         <div class="box box-simple">
-          <h5 class="box-h box-h-simple">{criterion.num}: {TRANSLATED.CRITERIA[criterion.num].TITLE}</h5>
+          <h5 class="box-h box-h-simple" id={`criterion-${criterion.num.replaceAll('.', '')}`}>{criterion.num}: {TRANSLATED.CRITERIA[criterion.num].TITLE}</h5>
           <div class="box-i">
             <h6>{TRANSLATED.HEADING_SCOPE_RESULTS}</h6>
             {#each scopeAssertion(criterion) as assertion}

--- a/src/components/ui/Auditor/AuditorView.svelte
+++ b/src/components/ui/Auditor/AuditorView.svelte
@@ -52,6 +52,12 @@
   {/each}
 </div>
 
+<style>
+  .Auditor__Assertion {
+    margin-left: -2rem;
+  }
+</style>
+
 <script>
   import { getContext } from 'svelte';
 

--- a/src/components/ui/Auditor/Criterion.svelte
+++ b/src/components/ui/Auditor/Criterion.svelte
@@ -6,32 +6,36 @@
   <header class="criterion-header">
     <h3>{num}: {TRANSLATED.CRITERION.TITLE}</h3>
     <em class="criterion-header__level">Level {conformanceLevel}</em>
-
-    <ResourceLink
-      href="https://www.w3.org/WAI/WCAG21/Understanding/{id}.html"
-    >
-      {TRANSLATED.UNDERSTAND_BUTTON}
-      {num}
-    </ResourceLink>
-    <ResourceLink href="https://www.w3.org/WAI/WCAG21/quickref/#{id}">
-      {TRANSLATED.HOW_TO_BUTTON}
-      {num}
-    </ResourceLink>
+    <div>
+      <ResourceLink
+        href="https://www.w3.org/WAI/WCAG21/Understanding/{id}.html"
+      >
+        {TRANSLATED.UNDERSTAND_BUTTON}
+        {num}
+      </ResourceLink>
+      <ResourceLink href="https://www.w3.org/WAI/WCAG21/quickref/#{id}">
+        {TRANSLATED.HOW_TO_BUTTON}
+        {num}
+      </ResourceLink>
+    </div>
   </header>
 
     {TRANSLATED.CRITERION.DESCRIPTION}
 
     {#if TRANSLATED.CRITERION.DETAILS}
-      <ul>
-        {#each Object.keys(TRANSLATED.CRITERION.DETAILS) as DETAIL}
-          <li>
-            <p>
-              {#if TRANSLATED.CRITERION.DETAILS[DETAIL].TITLE}<strong>{TRANSLATED.CRITERION.DETAILS[DETAIL].TITLE}</strong>:{/if}
-              {TRANSLATED.CRITERION.DETAILS[DETAIL].DESCRIPTION}
-            </p>
-          </li>
-        {/each}
-      </ul>
+      <details class="criterion-details">
+        <summary class="button button-secondary button-small criterion-details-button">{TRANSLATED.SHOW_FULL_DESCRIPTION}</summary>
+        <ul>
+          {#each Object.keys(TRANSLATED.CRITERION.DETAILS) as DETAIL}
+            <li>
+              <p>
+                {#if TRANSLATED.CRITERION.DETAILS[DETAIL].TITLE}<strong>{TRANSLATED.CRITERION.DETAILS[DETAIL].TITLE}</strong>:{/if}
+                {TRANSLATED.CRITERION.DETAILS[DETAIL].DESCRIPTION}
+              </p>
+            </li>
+          {/each}
+        </ul>
+      </details>
     {/if}
 
   <!--
@@ -76,6 +80,12 @@
 :global(.criterion:target) {
   outline: 2px solid var(--gold);
 }
+.criterion-details {
+  padding-left: 0;
+}
+.criterion-details-button {
+  margin: .5em 0 1.5em;
+}
 </style>
 
 <script>
@@ -103,7 +113,8 @@
     SCOPE_RESULT_LEGEND: $translate('PAGES.AUDIT.SAMPLE_FINDINGS'),
     SAMPLE_RESULTS_DETAILS_BUTTON: $translate('PAGES.AUDIT.BTN_EXPAND_PAGES'),
     RESULT_FOR_LABEL: $translate('PAGES.AUDIT.RESULTS_FOR'),
-    CRITERION: $translateToObject('WCAG.SUCCESS_CRITERION')[num]
+    CRITERION: $translateToObject('WCAG.SUCCESS_CRITERION')[num],
+    SHOW_FULL_DESCRIPTION: $translate('UI.COMMON.SHOW_FULL_DESCRIPTION')
   };
 
   $: test = $tests.find(($test) => {

--- a/src/components/ui/Auditor/Criterion.svelte
+++ b/src/components/ui/Auditor/Criterion.svelte
@@ -23,9 +23,16 @@
     {TRANSLATED.CRITERION.DESCRIPTION}
 
     {#if TRANSLATED.CRITERION.DETAILS}
-      <details class="criterion-details">
-        <summary class="button button-secondary button-small criterion-details-button">{TRANSLATED.SHOW_FULL_DESCRIPTION}</summary>
-        <ul>
+      <button 
+        type="button" 
+        class="showhidebutton button button-small"
+        aria-expanded={criterionDetailsOpen}
+        on:click={toggleCriterionDetails}
+      >
+        {TRANSLATED.SHOW_FULL_DESCRIPTION}
+      </button>
+      {#if criterionDetailsOpen}
+        <ul tabindex="-1" bind:this={criterionDetails}>
           {#each Object.keys(TRANSLATED.CRITERION.DETAILS) as DETAIL}
             <li>
               <p>
@@ -35,7 +42,7 @@
             </li>
           {/each}
         </ul>
-      </details>
+      {/if}
     {/if}
 
   <!--
@@ -104,6 +111,9 @@
   export let conformanceLevel;
   export let id;
   export let num;
+  export let criterionDetailsOpen = false;
+
+  let criterionDetails;
 
   const { translate, translateToObject } = getContext('app');
 
@@ -127,5 +137,14 @@
 
   function normaliseId(test) {
     return test.num.replaceAll('.','');
+  }
+
+  function toggleCriterionDetails() {
+    criterionDetailsOpen = !criterionDetailsOpen;
+    setTimeout(function() {
+      if (criterionDetailsOpen) {
+        criterionDetails.focus();
+      }
+    }, 100);
   }
 </script>

--- a/src/locales/en/PAGES/AUDIT.json
+++ b/src/locales/en/PAGES/AUDIT.json
@@ -33,5 +33,6 @@
     "TESTED": "Tested",
     "TITLE": "Step 4: Audit the Selected Sample",
     "UNDERSTAND": "Understanding",
-    "UNTESTED": "{{critCount}} untested"
+    "UNTESTED": "{{critCount}} untested",
+    "VIEW_IN_REPORT": "View in report"
 }

--- a/src/locales/en/UI/COMMON.json
+++ b/src/locales/en/UI/COMMON.json
@@ -21,5 +21,6 @@
     "LABEL": {
         "LANGUAGE_SELECT": "This page in"
     },
-    "YOUR_REPORT": "Your report"
+    "YOUR_REPORT": "Your report",
+    "SHOW_FULL_DESCRIPTION": "Show full description"
 }

--- a/src/locales/nl/PAGES/AUDIT.json
+++ b/src/locales/nl/PAGES/AUDIT.json
@@ -33,5 +33,6 @@
     "TESTED": "Getest",
     "TITLE": "Stap 4: Toets de sample",
     "UNDERSTAND": "Toelichting",
-    "UNTESTED": "{{critCount}} niet getest"
+    "UNTESTED": "{{critCount}} niet getest",
+    "VIEW_IN_REPORT": "Toon in rapport"
 }

--- a/src/locales/nl/UI/COMMON.json
+++ b/src/locales/nl/UI/COMMON.json
@@ -20,5 +20,6 @@
     "LABEL": {
         "LANGUAGE_SELECT": "Deze pagina in het"
     },
-    "YOUR_REPORT": "Jouw rapport"
+    "YOUR_REPORT": "Jouw rapport",
+    "SHOW_FULL_DESCRIPTION": "Toon volledige omschrijving"
 }


### PR DESCRIPTION
This PR: 

* adds 'View in report' links to audit fields for individual SCs
* uses 'show details' patterns for the 'details' segment of the success criterion text (usually this is where something is enumerated), so that the SC text is shown like it is in the WCAG QuickRef
* remove WAI `field` class so that focus style on fields are a bit more subtle (and it works better with 'View in report')

cc @nitedog 