### PR TITLE
Tweak behavior of Your Report box

### DIFF
--- a/src/components/layouts/BaseLayout.svelte
+++ b/src/components/layouts/BaseLayout.svelte
@@ -83,9 +83,8 @@
     STEP: $translate('UI.NAV.STEP', { default: 'step' }),
   };
 
-  $: hasPanel = !isViewReport && !isOverview;
+  $: hasPanel = !isViewReport;
   $: isViewReport = $location.pathname === $routes.VIEW_REPORT.path;
-  $: isOverview = $location.pathname === $routes.OVERVIEW.path;
 
   $: pagerContext = Object.keys($routes).map((key) => {
     return $routes[key];

--- a/src/components/pages/OverviewPage.svelte
+++ b/src/components/pages/OverviewPage.svelte
@@ -10,12 +10,6 @@
     {@html TRANSLATED.INTRODUCTION_P2}
   </p>
 
-  <p>
-    <OpenEvaluation />
-    <Button type="secondary" on:click="{handleNewEvaluationClick}">
-      {TRANSLATED.BUTTON_NEW_EVALUATION}
-    </Button>
-  </p>
   <details>
     <summary><h2>{TRANSLATED.USAGE_HEADING}</h2></summary>
     <ul>
@@ -38,19 +32,11 @@
 <!-- /component -->
 
 <script>
-  import { getContext, onMount } from 'svelte';
-  import { useNavigate } from 'svelte-navigator';
-
-  import Button from '@app/components/ui/Button.svelte';
-  import OpenEvaluation from '@app/components/form/OpenEvaluation.svelte';
+  import { getContext } from 'svelte';
 
   import Page from '@app/components/ui/Page.svelte';
 
-  import { routes } from '@app/stores/appStore.js';
-  import evaluationStore from '@app/stores/evaluationStore.js';
-
   const { translate } = getContext('app');
-  const navigate = useNavigate();
 
   $: TRANSLATED = {
     BUTTON_NEW_EVALUATION: $translate('UI.NAV.MENU_NEW', {
@@ -69,10 +55,4 @@
     TIPS_LI3: $translate('PAGES.START.TIPS_LI3'),
     TIPS_LI4: $translate('PAGES.START.TIPS_LI4')
   };
-
-  function handleNewEvaluationClick() {
-    $evaluationStore.reset();
-    navigate($routes.SCOPE.path, { replace: true });
-  }
-
 </script>

--- a/src/components/ui/YourReport.svelte
+++ b/src/components/ui/YourReport.svelte
@@ -1,63 +1,90 @@
 <Panel title="{siteName || TRANSLATED.HEADING_PANEL}" subtitle="{siteName ? TRANSLATED.REPORT_FOR : ''}">
+  {#if totalEvaluated > 0 || !isOverview}
+    <ReportNumbers criteria={criteriaCount}></ReportNumbers>
 
-  <ReportNumbers criteria={criteriaCount}></ReportNumbers>
-
-  <ProgressBar percentage={percentageTotalEvaluated}></ProgressBar>
-  
-  <ul class="your-report__progress-by-principle">
-    {#each principles as principle}
-    <li class="progress">
-      <div class="progress__principle">
-        <a href="#@@@" class="principle__name">
-          <span>{TRANSLATED.PRINCIPLES[principle].TITLE}</span>
-        </a> 
-        <span class="progress__part">{totalsPerPrinciple[principle]["done"]} of {totalsPerPrinciple[principle]["total"]}</span>
-      </div>
-      <ProgressBar percentage="{totalsPerPrinciple[principle]["percentage"]}"></ProgressBar>
-    </li>
-    {/each}
-  </ul>
-  
-  <Link class="button" to="/evaluation/view-report">
-    {TRANSLATED.VIEW_REPORT}
-  </Link>
+    <ProgressBar percentage={percentageTotalEvaluated}></ProgressBar>
+    
+    <ul class="your-report__progress-by-principle">
+      {#each principles as principle}
+      <li class="progress">
+        <div class="progress__principle">
+          <a href="#@@@" class="principle__name">
+            <span>{TRANSLATED.PRINCIPLES[principle].TITLE}</span>
+          </a> 
+          <span class="progress__part">{totalsPerPrinciple[principle]["done"]} of {totalsPerPrinciple[principle]["total"]}</span>
+        </div>
+        <ProgressBar percentage="{totalsPerPrinciple[principle]["percentage"]}"></ProgressBar>
+      </li>
+      {/each}
+    </ul>
+    
+    <Link class="button" to="/evaluation/view-report">
+      {TRANSLATED.VIEW_REPORT}
+    </Link>
+    {#if totalEvaluated > 0}
+    <Button type="secondary" on:click={handleClearEvaluationClick}>
+      {TRANSLATED.CLEAR_REPORT}
+    </Button>
+    {/if}
+  {:else}
+    <p>{TRANSLATED.NOT_STARTED}</p>
+    <Button on:click="{handleNewEvaluationClick}">
+      {TRANSLATED.BUTTON_NEW_EVALUATION}
+    </Button>
+    <OpenEvaluation />
+  {/if}
 </Panel>
 
 <style>  
 .your-report__progress-by-principle {
   columns: 1;
 }
+:global(.your-report .button + .File),
+:global(.your-report .button + .button) { 
+  margin-top: 4px; 
+}
 </style>
 
 <script>
   import { getContext } from 'svelte';
-  import { Link } from 'svelte-navigator';
+  import { Link, useNavigate, useLocation } from 'svelte-navigator';
 
   import Panel from '@app/components/ui/Panel.svelte';
   import ProgressBar from '@app/components/ui/ProgressBar.svelte';
   import ReportNumbers from '@app/components/ui/Report/ReportNumbers.svelte';
+  import OpenEvaluation from '@app/components/form/OpenEvaluation.svelte';
+  import Button from '@app/components/ui/Button.svelte';
 
   import { wcag, scopedWcagVersions } from '@app/stores/wcagStore.js';
+  import { routes } from '@app/stores/appStore.js';
   import assertions from '@app/stores/earl/assertionStore/index.js';
+  import evaluationStore from '@app/stores/evaluationStore.js';
 
   import { CriteriaSelected } from '@app/stores/selectedCriteriaStore.js';
   let criteriaCount = 0;
   $: criteriaCount = $CriteriaSelected.length;
   
+  const navigate = useNavigate();
+  const location = useLocation();
   const { translate, translateToObject, scopeStore } = getContext('app');
 
   $: TRANSLATED = {
-    PRINCIPLES: $translateToObject('WCAG.PRINCIPLE'),
     BUTTON_NEW_EVALUATION: $translate('UI.NAV.MENU_NEW', {
-      default: 'New report'
+      default: 'Start new report'
     }),
+    PRINCIPLES: $translateToObject('WCAG.PRINCIPLE'),
     HEADING_PANEL: $translate('UI.COMMON.YOUR_REPORT', {
       default: 'Your report'
     }),
     STEP: $translate('UI.NAV.STEP', { default: 'step' }),
-    VIEW_REPORT: $translate('UI.NAV.STEP_VIEWREPORT', {
+    VIEW_REPORT: $translate('UI.NAV.VIEWREPORT', {
       default: 'View report'
     }),
+    CLEAR_REPORT: $translate('UI.NAV.CLEARREPORT', {
+      default: 'Clear report'
+    }),
+    CLEAR_WARNING: $translate('UI.NAV.CLEARWARNING'),
+    NOT_STARTED: $translate('UI.NAV.NOT_STARTED'),
     CONFORMANCE_LEVEL: $translate('WCAG.COMMON.CONFORMANCE_LEVEL'),
     REPORT_FOR: $translate('UI.REPORT.REPORT_FOR'),
   };
@@ -114,6 +141,19 @@
     assertion.result.outcome.id !== "earl:untested"
   }
 
+  function handleNewEvaluationClick() {
+    $evaluationStore.reset();
+    navigate($routes.SCOPE.path, { replace: true });
+  }
+
+  function handleClearEvaluationClick() {
+    window.confirm(TRANSLATED.CLEAR_WARNING, function() {
+      $evaluationStore.reset();
+      navigate($routes.SCOPE.path, { replace: true });
+    });
+  }
+
+  $: isOverview = $location.pathname === $routes.OVERVIEW.path; 
   $: siteName = $scopeStore['SITE_NAME'];
   $: totalToEvaluate = $assertions.length;
   $: totalEvaluated = $assertions.filter(assertion => 

--- a/src/locales/en/UI/NAV.json
+++ b/src/locales/en/UI/NAV.json
@@ -3,9 +3,9 @@
     "MENU_IMPORT": "Import data",
     "MENU_IMPORT_HINT": "EARL as JSON-LD",
     "MENU_IMPORT_TITLE": "Start EARL report import wizzard",
-    "MENU_NEW": "New report",
-    "MENU_OPEN": "Open report",
-    "MENU_SAVE": "Save report",
+    "MENU_NEW": "Start New Report",
+    "MENU_OPEN": "Open Report",
+    "MENU_SAVE": "Save Report",
     "MENU_SAVE_TITLE": "Ctrl + S or ⌘ S",
     "MENU_RESOURCES": "Key Resources",
     "MENU_LANGUAGE": "Language",
@@ -26,5 +26,9 @@
     "STEP_AUDIT": "Audit Sample",
     "STEP_REPORT": "Report Findings",
     "STEP_VIEWREPORT": "View Report",
+    "VIEWREPORT": "View Report",
+    "CLEARREPORT": "Clear Report",
+    "NOT_STARTED": "No report started.",
+    "CLEARWARNING": "This will clear the current evaluation and start a new one. Are you sure that is what you would like to do?",
     "BTN_BACK_TO_EVAL": "Back"
 }

--- a/src/locales/nl/PAGES/AUDIT.json
+++ b/src/locales/nl/PAGES/AUDIT.json
@@ -34,7 +34,7 @@
     "TITLE": "Stap 4: Toets de sample",
     "UNDERSTAND": "Toelichting",
     "UNTESTED": "{{critCount}} niet getest",
-    "VIEW_IN_REPORT": "Toon in rapport",
+    "VIEW_IN_REPORT": "In rapport",
     "LABEL_VERSION": "Versie van WCAG",
     "LABEL_LEVEL": "Conformanceniveau"
 }

--- a/src/locales/nl/UI/NAV.json
+++ b/src/locales/nl/UI/NAV.json
@@ -25,5 +25,9 @@
     "STEP_AUDIT": "Toets Sample",
     "STEP_REPORT": "Rapporteer Resultaat",
     "STEP_VIEWREPORT": "Bekijk Rapport",
+    "VIEWREPORT": "Bekijk rapport",
+    "NOT_STARTED": "Nog niet aan een rapport begonnen.",
+    "CLEARREPORT": "Opnieuw",
+    "CLEARWARNING": "Dit zal alles wat nu is ingevoerd verwijderen en een nieuw rapport starten. Weet u het zeker?",
     "BTN_BACK_TO_EVAL": "Terug"
 }

--- a/src/static/css/global.css
+++ b/src/static/css/global.css
@@ -63,6 +63,10 @@ textarea {
   font-family: 'Noto Sans Mono', monospace;
 }
 
+.your-report {
+  padding: 0.9em; /* to fit WCAG EM Report Tool View + Clear buttons */
+}
+
 /*
  * Remove default focus styles from elements that
  * otherwise should not receive focus.


### PR DESCRIPTION
So that it is like that of the ATAG Report Tool.

Displays progress on all evaluation pages, and on the overview page if at least one SC is evaluated.

Displays ‘no report started’ on Overview page if no SC was evaluated yet.

Displays ‘Clear report’ button if at least one SC is evaluated.

Signed-off-by: Hidde de Vries <hidde@hiddedevries.nl>