### PR TITLE
#498 Fix for counters with imported report

### DIFF
--- a/src/components/form/EarlResult.svelte
+++ b/src/components/form/EarlResult.svelte
@@ -84,6 +84,8 @@
   import Select from '@app/components/form/Select.svelte';
   import Textarea from '@app/components/form/Textarea.svelte';
 
+  import { CriteriaSelected } from '@app/stores/selectedCriteriaStore.js';
+
   export let label = undefined;
   // Used to display subject.title
   export let subject = {};

--- a/src/components/pages/Evaluation/DefineScopePage.svelte
+++ b/src/components/pages/Evaluation/DefineScopePage.svelte
@@ -69,6 +69,12 @@
   import { getContext, onMount } from 'svelte';
 
   import { CONFORMANCE_LEVELS, WCAG_VERSIONS, scopedWcagVersions } from '@app/stores/wcagStore.js';
+  import assertions from '@app/stores/earl/assertionStore/index.js';
+  import { CriteriaSelected } from '@app/stores/selectedCriteriaStore.js';
+  import tests from '@app/stores/earl/testStore/index.js';
+  import subjects, {
+    TestSubjectTypes
+  } from '@app/stores/earl/subjectStore/index.js';
 
   import Page from '@app/components/ui/Page.svelte';
   import Input from '@app/components/form/Input.svelte';
@@ -117,5 +123,42 @@
   });
 
   const { scopeStore } = getContext('app');
+
+  // Used to display subject.title
+  export let subject = {};
+
+  // Used for id creation (test.id)
+  export let test = {};
+
+  $: if(true){
+    // Get or create an Assertion
+    const available = [];
+    $CriteriaSelected.forEach((criteria) => {
+      const check = criteria.num;
+      available.push(check);
+      subject = $subjects.find((subject) => {
+        return subject.type.indexOf(TestSubjectTypes.WEBSITE) >= 0;
+    });
+
+    test = $tests.find(($test) => {
+      return $test.num === check;
+    });
+      
+    $assertions.find(($assertion) => {
+      const matchedTest = $assertion.test === test;
+      const matchedSubject = $assertion.subject === subject;
+
+      return matchedTest && matchedSubject;
+      }) || assertions.create({ subject, test });
+    });
+
+    assertionsToRemove = $assertions.filter((assertion) => {
+      return available.indexOf(assertion.test.num) == -1;
+    });
+
+    assertionsToRemove.forEach((assertion) => {
+      assertions.remove(assertion);
+    });
+  }  
 
 </script>

--- a/src/components/ui/Report/ReportNumbers.svelte
+++ b/src/components/ui/Report/ReportNumbers.svelte
@@ -26,7 +26,6 @@
   };
 
   $: totalEvaluated = $assertions.filter(assertion => 
-    assertion.subject.title == "" &&
    assertion.result.outcome.id !== "earl:untested").length;
 
 </script>

--- a/src/components/ui/Report/ReportSummary.svelte
+++ b/src/components/ui/Report/ReportSummary.svelte
@@ -67,13 +67,20 @@
           items: $CriteriaSelected
         };
         final.push(value);
+    }else if(outcomeValue.id == "earl:untested"){
+      const value = {
+          name: outcomeValue.title,
+          id: outcomeValue.id,
+          items: $assertions.filter(assertion => 
+            assertion.result.outcome.id === outcomeValue.id)
+        };
+        final.push(value);
     }else{
         const value = {
           name: outcomeValue.title,
           id: outcomeValue.id,
           items: $assertions.filter(assertion => 
-            assertion.result.outcome.id === outcomeValue.id && 
-            assertion.subject.title == "")
+            assertion.result.outcome.id === outcomeValue.id)
         };
         final.push(value);
     }

--- a/src/components/ui/YourReport.svelte
+++ b/src/components/ui/YourReport.svelte
@@ -146,7 +146,7 @@
   };
 
   function isEvaluated(assertion) {
-    return assertion.result.outcome.id !== "earl:untested" && assertion.subject.title == ""
+    return assertion.result.outcome.id !== "earl:untested"
   }
 
   function handleNewEvaluationClick() {
@@ -175,8 +175,7 @@
   $: isAuditSample = $location.pathname === $routes.AUDIT.path; 
   $: siteName = $scopeStore['SITE_NAME'];
   $: totalToEvaluate = $assertions.filter(assertion => 
-    assertion.subject.title == "").length;
+    assertion.result.outcome.id == "earl:untested").length;
   $: totalEvaluated = $assertions.filter(assertion => 
-    assertion.subject.title == "" &&
    assertion.result.outcome.id !== "earl:untested").length;
 </script>

--- a/src/stores/collectionStore.js
+++ b/src/stores/collectionStore.js
@@ -3,11 +3,18 @@ import { writable } from 'svelte/store';
 export default function collectionStore(Item, initialCollection = []) {
   const collection = writable([...initialCollection]);
 
+  // Re-initialize
+  collection.reset = function reset() {
+    collection.update(() => {
+      return [...initialCollection];
+    });
+  };
+
   collection.create = function create(value) {
+
     if (typeof value !== 'object') {
       value = { value };
     }
-
     const newItem = Item ? new Item(value) : { ...value };
 
     collection.update((value) => {
@@ -15,14 +22,6 @@ export default function collectionStore(Item, initialCollection = []) {
     });
 
     return newItem;
-  };
-
-  // Re-initialize
-  collection.reset = function reset() {
-    console.log('Collection reset', initialCollection);
-    collection.update(() => {
-      return [...initialCollection];
-    });
   };
 
   collection.remove = function remove(removeItem) {


### PR DESCRIPTION
This also fixes the initialisation of the assertions on the define scope page, with the corrent numbers to be counted and displayed available from the moment you start  creating/importing the report